### PR TITLE
Fix up the signal handler so if SIGKILL or SIGSTOP is sent with noact…

### DIFF
--- a/linux-user/signal.c
+++ b/linux-user/signal.c
@@ -787,8 +787,21 @@ int do_sigaction(int sig, const struct target_sigaction *act,
     int host_sig;
     int ret = 0;
 
-    if (sig < 1 || sig > TARGET_NSIG || sig == TARGET_SIGKILL || sig == TARGET_SIGSTOP) {
+    if (sig < 1 || sig > TARGET_NSIG) {
         return -TARGET_EINVAL;
+    }
+
+    /* Allow reading the handler for SIGKILL/SIGSTOP (always SIG_DFL),
+       but reject attempts to change it — matches real kernel behavior. */
+    if (sig == TARGET_SIGKILL || sig == TARGET_SIGSTOP) {
+        if (act) {
+            return -TARGET_EINVAL;
+        }
+        if (oact) {
+            memset(oact, 0, sizeof(*oact));
+            __put_user(TARGET_SIG_DFL, &oact->_sa_handler);
+        }
+        return 0;
     }
 
     if (block_signals()) {


### PR DESCRIPTION
Current upstream qemu seems to adopt a similar approach here.

Bionic's posix_spawn (used by system()) iterates all signals calling
sigaction(sig, NULL, &old) to check existing handlers before exec.
QEMU's do_sigaction() unconditionally rejects SIGKILL and SIGSTOP,
even for read-only queries (act==NULL), causing posix_spawn to fail
with EINVAL and the child to exit(127).


The real Linux kernel allows sigaction reads on SIGKILL/SIGSTOP —
it just reports SIG_DFL and refuses to change them. This patch
matches that behavior: read-only queries return SIG_DFL in oact,
while attempts to install a new handler still get EINVAL.
