### PR TITLE
[WIP] Split TCG load-check ordering: probe-before for usermode, probe-after…

### DIFF
--- a/accel/tcg/tcg-runtime-symsan.c
+++ b/accel/tcg/tcg-runtime-symsan.c
@@ -1348,7 +1348,7 @@ void HELPER(symsan_check_load_guest)(CPUArchState *env, target_ulong addr, uint6
     }
 }
 void HELPER(symsan_check_store_guest)(CPUArchState *env, target_ulong addr, uint64_t length, uint64_t mmu_idx){
-    assert(second_ccache_flag != 1);
+    if (second_ccache_flag == 1) return;
     uint32_t value_label = 0;
     //void *host_addr = tlb_vaddr_to_host(env, addr, MMU_DATA_STORE, mmu_idx);
     void *host_addr = tlb_vaddr_to_host(env, addr, MMU_DATA_STORE, mmu_idx);

--- a/tcg/tcg-op.c
+++ b/tcg/tcg-op.c
@@ -3471,6 +3471,32 @@ void tcg_gen_qemu_ld_i32(TCGv_i32 val, TCGv addr, TCGArg idx, TCGMemOp memop)
     tcg_gen_mov_tl(saved_addr, addr);
     TCGv_i64 mmu_idx = tcg_const_i64(idx);
     load_size = tcg_const_i64(1 << (memop & MO_SIZE));
+#ifdef CONFIG_USER_ONLY
+    /*
+     * User mode: probe BEFORE the concrete load.  If check_load_guest
+     * detects symbolic data it raises EXCP_SWITCH, which replays the
+     * instruction in symbolic mode.  Checking after the load would leave
+     * the destination register clobbered (e.g. ldr x0,[x0] overwrites x0
+     * with the loaded value before the replay can re-read the address).
+     * User mode has no hardware TLB, so probing before the load is safe.
+     */
+    if (!second_ccache_flag) {
+        gen_helper_symsan_check_load_guest(cpu_env, saved_addr, load_size,
+                                           mmu_idx);
+    }
+    gen_ldst_i32(INDEX_op_qemu_ld_i32, val, addr, memop, idx);
+    if (second_ccache_flag) {
+        gen_helper_symsan_load_guest_i32(shadow_i32(val), cpu_env,
+                                         saved_addr,
+                                         tcgv_i64_expr_num(saved_addr),
+                                         load_size, mmu_idx);
+    }
+#else
+    /*
+     * System mode: probe AFTER the concrete load so the TLB is already
+     * populated.  Probing before the load triggers x86_cpu_tlb_fill
+     * g_assert(!probe) on demand-paged addresses during boot.
+     */
     gen_ldst_i32(INDEX_op_qemu_ld_i32, val, addr, memop, idx);
     if (second_ccache_flag) {
         gen_helper_symsan_load_guest_i32(shadow_i32(val), cpu_env,
@@ -3478,16 +3504,10 @@ void tcg_gen_qemu_ld_i32(TCGv_i32 val, TCGv addr, TCGArg idx, TCGMemOp memop)
                                          tcgv_i64_expr_num(saved_addr),
                                          load_size, mmu_idx);
     } else {
-        /*
-         * Probe AFTER the concrete load so the target page is already in the
-         * TLB, mirroring the store path above. Probing before the load made
-         * i386's x86_cpu_tlb_fill() abort (g_assert(!probe)) on demand-paged
-         * addresses during boot. saved_addr still holds the pre-load address,
-         * so a later switch-to-symbolic replay uses the correct address.
-         */
         gen_helper_symsan_check_load_guest(cpu_env, saved_addr, load_size,
                                            mmu_idx);
     }
+#endif
     tcg_temp_free_i64(load_size);
     tcg_temp_free_i64(mmu_idx);
     tcg_temp_free(saved_addr);
@@ -3613,22 +3633,30 @@ void tcg_gen_qemu_ld_i64(TCGv_i64 val, TCGv addr, TCGArg idx, TCGMemOp memop)
     load_size = tcg_const_i64(1 << (memop & MO_SIZE));
     TCGv_i64 mmu_idx = tcg_const_i64(idx);
 
+#ifdef CONFIG_USER_ONLY
+    /* User mode: probe before the load — same rationale as the i32 path. */
+    if (!second_ccache_flag) {
+        gen_helper_symsan_check_load_guest(cpu_env, saved_addr, load_size,
+                                           mmu_idx);
+    }
     gen_ldst_i64(INDEX_op_qemu_ld_i64, val, addr, memop, idx);
-
+    if (second_ccache_flag) {
+        gen_helper_symsan_load_guest_i64(tcgv_i64_expr_num(val), cpu_env,
+                                         saved_addr, tcgv_i64_expr_num(saved_addr),
+                                         load_size, mmu_idx);
+    }
+#else
+    /* System mode: probe after the load for TLB population. */
+    gen_ldst_i64(INDEX_op_qemu_ld_i64, val, addr, memop, idx);
     if (second_ccache_flag) {
         gen_helper_symsan_load_guest_i64(tcgv_i64_expr_num(val), cpu_env,
                                          saved_addr, tcgv_i64_expr_num(saved_addr),
                                          load_size, mmu_idx);
     } else {
-        /*
-         * Probe AFTER the concrete load so the target page is already in the
-         * TLB, mirroring the store path. Probing before the load made i386's
-         * x86_cpu_tlb_fill() abort (g_assert(!probe)) on demand-paged addresses
-         * during boot. saved_addr still holds the pre-load address, so a later
-         * switch-to-symbolic replay uses the correct address.
-         */
-        gen_helper_symsan_check_load_guest(cpu_env, saved_addr, load_size, mmu_idx);
+        gen_helper_symsan_check_load_guest(cpu_env, saved_addr, load_size,
+                                           mmu_idx);
     }
+#endif
     tcg_temp_free_i64(load_size);
     tcg_temp_free_i64(mmu_idx);
     /*


### PR DESCRIPTION
Please do not accept the pull request yet. Please build and test and ensure it does not break the system side of things. In usermode we were seeing symbolic values appear in concrete memory, causing corruption.